### PR TITLE
Fix typo and improve tests

### DIFF
--- a/src/Exception/UnknownServiceException.php
+++ b/src/Exception/UnknownServiceException.php
@@ -18,6 +18,6 @@ class UnknownServiceException extends RuntimeException
 
     public static function fromServiceName(string $service, ?Throwable $previous = null): self
     {
-        return new self(sprintf('Unknown Goole service: "%s".', $service), $previous);
+        return new self(sprintf('Unknown Google service: "%s".', $service), $previous);
     }
 }

--- a/tests/Unit/Helper/ColumnNameCalculatorTest.php
+++ b/tests/Unit/Helper/ColumnNameCalculatorTest.php
@@ -20,7 +20,7 @@ class ColumnNameCalculatorTest extends TestCase
         self::assertSame($letter, ColumnNameCalculator::getColumnNameFromNumber($number));
     }
 
-    private function values(): array
+    public static function values(): array
     {
         return [
             [1, 'A'],

--- a/tests/Unit/Service/GoogleSpreadsheetWriterTest.php
+++ b/tests/Unit/Service/GoogleSpreadsheetWriterTest.php
@@ -56,7 +56,7 @@ class GoogleSpreadsheetWriterTest extends TestCase
         $writer = new GoogleSpreadsheetWriter($sheet);
 
         self::expectException(FailedToWriteFileException::class);
-        self::expectExceptionMessage('Failed to write data to spreadsheet with id: "spreadsheet_id');
+        self::expectExceptionMessage('Failed to write data to spreadsheet with id: "spreadsheet_id".');
         $writer->write('spreadsheet_id', 'sheet_name', $request);
     }
 


### PR DESCRIPTION
## Summary
- fix message typo in `UnknownServiceException`
- expect full error message in GoogleSpreadsheetWriter test
- make `values` data provider public for PHPUnit

## Testing
- `composer test` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_b_687e3197e5a08323976779c7578fc5e3