### PR TITLE
Fix GoogleSpreadsheetWriter error message test

### DIFF
--- a/tests/Unit/Service/GoogleSpreadsheetWriterTest.php
+++ b/tests/Unit/Service/GoogleSpreadsheetWriterTest.php
@@ -56,7 +56,7 @@ class GoogleSpreadsheetWriterTest extends TestCase
         $writer = new GoogleSpreadsheetWriter($sheet);
 
         self::expectException(FailedToWriteFileException::class);
-        self::expectExceptionMessage('Failed to write data to spreadsheet with id: "spreadsheet_id');
+        self::expectExceptionMessage('Failed to write data to spreadsheet with id: "spreadsheet_id".');
         $writer->write('spreadsheet_id', 'sheet_name', $request);
     }
 


### PR DESCRIPTION
## Summary
- correct the expected failure message in `GoogleSpreadsheetWriterTest`

## Testing
- `./vendor/bin/phpunit --configuration phpunit.xml.dist` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_687e338dde0c8323aac81e393fcdb2ac