### PR TITLE
Fix Google service typo

### DIFF
--- a/src/Exception/UnknownServiceException.php
+++ b/src/Exception/UnknownServiceException.php
@@ -18,6 +18,6 @@ class UnknownServiceException extends RuntimeException
 
     public static function fromServiceName(string $service, ?Throwable $previous = null): self
     {
-        return new self(sprintf('Unknown Goole service: "%s".', $service), $previous);
+        return new self(sprintf('Unknown Google service: "%s".', $service), $previous);
     }
 }


### PR DESCRIPTION
## Summary
- fix a typo in the UnknownServiceException message

## Testing
- `composer lint`
- `composer test` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_b_687e33955bec8323b44985b4ccf8d6a3