### PR TITLE
Fix typo in UnknownServiceException message

### DIFF
--- a/src/Exception/UnknownServiceException.php
+++ b/src/Exception/UnknownServiceException.php
@@ -18,6 +18,6 @@ class UnknownServiceException extends RuntimeException
 
     public static function fromServiceName(string $service, ?Throwable $previous = null): self
     {
-        return new self(sprintf('Unknown Goole service: "%s".', $service), $previous);
+        return new self(sprintf('Unknown Google service: "%s".', $service), $previous);
     }
 }


### PR DESCRIPTION
## Summary
- correct typo in UnknownServiceException error message

## Testing
- `composer lint`
- `composer unit` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_b_687e33d3a8f48323acec03d314b445ca